### PR TITLE
Fix flow identification and indices

### DIFF
--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1953,7 +1953,7 @@ class KeycloakAPI(object):
             newSubFlow["provider"] = "registration-page-form"
             newSubFlow["type"] = "basic-flow"
             newSubFlow["description"] = ""
-            open_url(
+            return open_url(
                 URL_AUTHENTICATION_FLOW_EXECUTIONS_FLOW.format(
                     url=self.baseurl,
                     realm=realm,
@@ -1977,7 +1977,7 @@ class KeycloakAPI(object):
             newExec = {}
             newExec["provider"] = execution["providerId"]
             newExec["requirement"] = execution["requirement"]
-            open_url(
+            return open_url(
                 URL_AUTHENTICATION_FLOW_EXECUTIONS_EXECUTION.format(
                     url=self.baseurl,
                     realm=realm,


### PR DESCRIPTION
##### SUMMARY
The current ansible modules do not handle properly flows executions creation.

The error comes from the fact that the created executions are identified either by their displayName or providerId which allows them to clash when two executions have the same providerId (e.g. set-attribute).

Also, the executions order is not correctly set as modification to the order on the server side are not propagated on the scripts.


##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
Ansible modules for keycloak flows configuration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
